### PR TITLE
Update USER.md for CP2K

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/USER.md
+++ b/easybuild/easyconfigs/c/CP2K/USER.md
@@ -16,7 +16,7 @@ page](https://docs.lumi-supercomputer.eu/software/installing/easybuild/). For ex
 Then you can run the install command
 
 ```bash
-$ eb CP2K-2023.1-cpeGNU-22.08-GPU.eb
+$ eb CP2K-2023.1-cpeGNU-22.08-GPU.eb -r
 ```
 
 The installation process is quite slow. It can take up to 1 hour to compile everything, but afterwards, you will have a module called "CP2K/2023.1-cpeGNU-22.08-GPU" installed in your home directory. Load the module to use it:


### PR DESCRIPTION
Using the instructions as provided on a clean installation result in the following error:
```
== Temporary log file in case of crash /run/user/327001883/easybuild/tmp/eb-up1fmr6g/easybuild-cuek8zyv.log
== processing EasyBuild easyconfig /appl/lumi/LUMI-EasyBuild-contrib/easybuild/easyconfigs/c/CP2K/CP2K-2023.1-cpeGNU-22.08-GPU.eb
== building and installing CP2K/2023.1-cpeGNU-22.08-GPU...
== fetching files...
== ... (took 1 secs)
== creating build dir, resetting environment...
== unpacking...
== ... (took 11 secs)
== patching...
== preparing...
== ... (took 6 secs)
== FAILED: Installation ended unsuccessfully (build directory: /run/user/327001883/easybuild/build/CP2K/2023.1/cpeGNU-22.08-GPU): build failed (first 300 chars): 
Missing modules for dependencies (use --robot?): ELPA/2022.11.001.rc1-cpeGNU-22.08-CPU, Libint-CP2K/2.6.0-cpeGNU-22.08, libvori/220621-cpeGNU-22.08, 
libxc/6.1.0-cpeGNU-22.08, libxsmm/1.17-cpeGNU-22.08, spglib/1.16.3-cpeGNU-22.08, COSMA/2.6.2-cpeGNU-22.08, SPLA/1.5.4-cpeGNU-22.08-GPU, SpFFT/1.0.6-cpe (took 19 secs)
== Results of the build can be found in the log file(s) /run/user/327001883/easybuild/tmp/eb-up1fmr6g/easybuild-CP2K-2023.1-20240205.191527.WRGwQ.log

ERROR: Build of /appl/lumi/LUMI-EasyBuild-contrib/easybuild/easyconfigs/c/CP2K/CP2K-2023.1-cpeGNU-22.08-GPU.eb failed (err: 'build failed (first 300 chars): Missing modules for dependencies (use --robot?): ELPA/2022.11.001.rc1-cpeGNU-22.08-CPU, Libint-CP2K/2.6.0-cpeGNU-22.08, libvori/220621-cpeGNU-22.08, libxc/6.1.0-cpeGNU-22.08, libxsmm/1.17-cpeGNU-22.08, spglib/1.16.3-cpeGNU-22.08, COSMA/2.6.2-cpeGNU-22.08, SPLA/1.5.4-cpeGNU-22.08-GPU, SpFFT/1.0.6-cpe')
```

The `-r` option is needed to also install all the necessary dependencies.